### PR TITLE
Add encryption to root block device

### DIFF
--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -80,6 +80,11 @@ variable "key_name" {
   default = ""
 }
 
+variable "root_vol_encrypted" {
+  type    = bool
+  default = true
+}
+
 variable "root_vol_size" {
   type    = string
   default = ""
@@ -114,4 +119,3 @@ variable "internal" {
   type    = string
   default = "true"
 }
-

--- a/group/lc/main.tf
+++ b/group/lc/main.tf
@@ -42,6 +42,7 @@ resource "aws_launch_configuration" "lc" {
   user_data  = var.user_data
 
   root_block_device {
+    encrypted             = var.root_vol_encrypted
     delete_on_termination = var.root_vol_del_on_term
     iops                  = var.root_vol_type == "io1" ? var.root_vol_iops : "0"
     volume_size           = length(var.root_vol_size) > 0 ? var.root_vol_size : "8"
@@ -72,6 +73,7 @@ resource "aws_launch_configuration" "lc_ebs" {
   user_data  = var.user_data
 
   root_block_device {
+    encrypted             = var.root_vol_encrypted
     delete_on_termination = var.root_vol_del_on_term
     iops                  = var.root_vol_type == "io1" ? var.root_vol_iops : "0"
     volume_size           = length(var.root_vol_size) > 0 ? var.root_vol_size : "0"
@@ -92,4 +94,3 @@ resource "aws_launch_configuration" "lc_ebs" {
     create_before_destroy = true
   }
 }
-

--- a/group/lc/variables.tf
+++ b/group/lc/variables.tf
@@ -81,6 +81,10 @@ variable "placement_tenancy" {
   type = string
 }
 
+variable "root_vol_encrypted" {
+  type = bool
+}
+
 variable "root_vol_del_on_term" {
   type = string
 }
@@ -108,4 +112,3 @@ variable "spot_price" {
 variable "user_data" {
   type = string
 }
-

--- a/group/main.tf
+++ b/group/main.tf
@@ -75,6 +75,7 @@ module "lc" {
   instance_type               = var.instance_type
   key_name                    = var.key_name
   placement_tenancy           = var.placement_tenancy
+  root_vol_encrypted          = var.root_vol_encrypted
   root_vol_del_on_term        = var.root_vol_del_on_term
   root_vol_iops               = var.root_vol_iops
   root_vol_size               = var.root_vol_size
@@ -123,4 +124,3 @@ module "asg" {
   target_group_arns     = var.target_group_arns
   wait_for_elb_capacity = var.wait_for_elb_capacity
 }
-

--- a/group/variables.tf
+++ b/group/variables.tf
@@ -154,6 +154,12 @@ variable "placement_tenancy" {
   default     = "default"
 }
 
+variable "root_vol_encrypted" {
+  type        = bool
+  description = "Whether the root volume should be encrypted or not."
+  default     = false
+}
+
 variable "root_vol_del_on_term" {
   type        = string
   description = "Whether the volume should be destroyed on instance termination."
@@ -307,4 +313,3 @@ variable "wait_for_elb_capacity" {
   description = "Setting this will cause Terraform to wait for exactly this number of healthy instances in all attached load balancers on both create and update operations. (Takes precedence over 'min_elb_capacity' behavior.)"
   default     = ""
 }
-


### PR DESCRIPTION
This pull request adds the ability to encrypt root volume EBS block devices.

A new variable `root_vol_encrypted` is created to toggle the feature. This new variable is very similar to the existing `ebs_vol_encrypted` variable used to encrypt attached EBS block devices and behaves in a similar fashion.