### PR TITLE
DEVOPS-4320 | Update module to support IMDSv2 enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ and also serves as a unique key for re-use.
 addresses with instances managed by the auto scaling group.
 * `ebs_optimized` - (Default: **false**) Flag to enable Elastic Block Storage
 (EBS) optimization.
-* `enable_imdsv2` - (Optional) Flag to enforce Instance Metadata Service IMDSv2.
+* `enable_imdsv2` - (Default: false) Flag to enforce Instance Metadata Service IMDSv2.
 * `enable_monitoring` - (Optional) Flag to enable detailed monitoring.
 * `instance_based_naming_enabled` - (Optional) Flag to enable dynamic name tags
 on instances. The default format is **stack_item_label-instance-id**. Requires

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ and also serves as a unique key for re-use.
 addresses with instances managed by the auto scaling group.
 * `ebs_optimized` - (Default: **false**) Flag to enable Elastic Block Storage
 (EBS) optimization.
+* `enable_imdsv2` - (Optional) Flag to enforce Instance Metadata Service IMDSv2.
 * `enable_monitoring` - (Optional) Flag to enable detailed monitoring.
 * `instance_based_naming_enabled` - (Optional) Flag to enable dynamic name tags
 on instances. The default format is **stack_item_label-instance-id**. Requires

--- a/group/lt/main.tf
+++ b/group/lt/main.tf
@@ -64,6 +64,18 @@ resource "aws_launch_template" "lt" {
     }
   }
 
+  # Replace with a simple "metadata_options" block when rolling out to Prod.
+  # This ensures we don't introduce drift to Prod in the meantime.
+  dynamic "metadata_options" {
+    for_each = var.enable_imdsv2 ? [1] : []
+
+    content {
+      http_endpoint               = "enabled"
+      http_tokens                 = "required"
+      http_put_response_hop_limit = 1
+    }
+  }
+
   instance_type = var.instance_type
   key_name      = var.key_name
 

--- a/group/lt/variables.tf
+++ b/group/lt/variables.tf
@@ -1,9 +1,10 @@
 # Input Variables
 
 ## Resource tags
+#Remove this var when rolling out IMDSv2 to Prod
 variable "enable_imdsv2" {
   type    = bool
-  default = false #Remove when rolling out IMDSv2 to Prod
+  default = false
 }
 
 variable "stack_item_fullname" {

--- a/group/lt/variables.tf
+++ b/group/lt/variables.tf
@@ -1,6 +1,11 @@
 # Input Variables
 
 ## Resource tags
+variable "enable_imdsv2" {
+  type    = bool
+  default = false #Remove when rolling out IMDSv2 to Prod
+}
+
 variable "stack_item_fullname" {
   type = string
 }

--- a/group/main.tf
+++ b/group/main.tf
@@ -1,7 +1,7 @@
 # AWS Auto Scaling Configuration
 
 locals {
-  instance_market_options = var.spot_price == "" ? { market_type = null, spot_options = { max_price = null }} : { market_type = "spot", spot_options = { max_price = var.spot_price }}
+  instance_market_options = var.spot_price == "" ? { market_type = null, spot_options = { max_price = null } } : { market_type = "spot", spot_options = { max_price = var.spot_price } }
   placement               = var.placement_tenancy == "" ? { tenancy = null } : { tenancy = var.placement_tenancy }
 }
 
@@ -75,6 +75,7 @@ module "lt" {
   ebs_vol_size                = var.ebs_vol_size
   ebs_vol_snapshot_id         = var.ebs_vol_snapshot_id
   ebs_vol_type                = var.ebs_vol_type
+  enable_imdsv2               = var.enable_imdsv2
   enable_monitoring           = var.enable_monitoring
   instance_market_options     = local.instance_market_options
   instance_profile            = var.instance_profile

--- a/group/variables.tf
+++ b/group/variables.tf
@@ -1,6 +1,12 @@
 # Input Variables
 
 ## Resource tags
+#Remove this var when rolling out IMDSv2 to Prod
+variable "enable_imdsv2" {
+  type    = bool
+  default = false
+}
+
 variable "stack_item_fullname" {
   type        = string
   description = "Long form descriptive name for this stack item. This value is used to create the 'application' resource tag for resources created by this stack item."


### PR DESCRIPTION
**Description**
Update module to support IMDSv2 enforcement. We'll define a default value of `enable_imdsv2=false` to avoid impacting stacks which depend on this module. Once all the downstream stacks are updated we can loop back to force IMDSv2 in the module.

**Ticket**
[DEVOPS-4320]

**Status**
No changes to apply.

[DEVOPS-4320]: https://taskrabbit.atlassian.net/browse/DEVOPS-4320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ