### PR TITLE
DEVOPS-4320 | Increase hop limit for metadata requests

### DIFF
--- a/group/lt/main.tf
+++ b/group/lt/main.tf
@@ -72,7 +72,7 @@ resource "aws_launch_template" "lt" {
     content {
       http_endpoint               = "enabled"
       http_tokens                 = "required"
-      http_put_response_hop_limit = 1
+      http_put_response_hop_limit = 2
     }
   }
 


### PR DESCRIPTION
**Description**
Increasing `http-put-response-hop-limit` to 2 from 1 is required because Jenkins jobs execute Terraform from a Docker container so an extra hop is needed for metadata requests.

**Ticket**
[DEVOPS-4320]

**Status**
No changes to apply.

[DEVOPS-4320]: https://taskrabbit.atlassian.net/browse/DEVOPS-4320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ