### PR TITLE
DEVOPS-4320 | Update runcmd to be compatible with IMDSv2

### DIFF
--- a/group/templates/name.tpl
+++ b/group/templates/name.tpl
@@ -1,5 +1,6 @@
 #cloud-config
 runcmd:
   - TOKEN=$(curl -H "X-aws-ec2-metadata-token-ttl-seconds: 300" -X PUT "http://169.254.169.254/latest/api/token")
-  - "`which aws` ec2 create-tags --region=${region} --resources `curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/instance-id` --tags Key=Name,Value=${name_prefix}-`curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/instance-id | tr -d 'i-'`"
+  - INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s "http://169.254.169.254/latest/meta-data/instance-id")
+  - "`which aws` ec2 create-tags --region=${region} --resources $INSTANCE_ID --tags Key=Name,Value=${name_prefix}-`echo $INSTANCE_ID` | tr -d 'i-'`"
 output : { all : '| tee -a /var/log/cloud-init-output.log' }

--- a/group/templates/name.tpl
+++ b/group/templates/name.tpl
@@ -1,6 +1,6 @@
 #cloud-config
 runcmd:
-  - export TOKEN=$(curl -H "X-aws-ec2-metadata-token-ttl-seconds: 300" -X PUT "http://169.254.169.254/latest/api/token")
+  - export TOKEN=$(curl -H "X-aws-ec2-metadata-token-ttl-seconds: 60" -X PUT "http://169.254.169.254/latest/api/token")
   - export INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s "http://169.254.169.254/latest/meta-data/instance-id")
   - "`which aws` ec2 create-tags --region=${region} --resources $INSTANCE_ID --tags Key=Name,Value=${name_prefix}-`echo $INSTANCE_ID` | tr -d 'i-'`"
   - unset TOKEN

--- a/group/templates/name.tpl
+++ b/group/templates/name.tpl
@@ -1,8 +1,13 @@
 #cloud-config
 runcmd:
-  - export TOKEN=$(curl -H "X-aws-ec2-metadata-token-ttl-seconds: 1800" -X PUT "http://169.254.169.254/latest/api/token")
-  - export INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s "http://169.254.169.254/latest/meta-data/instance-id")
-  #- unset TOKEN
+  # Fetch IMDSv2 token
+  - |
+    TOKEN=$(curl -H "X-aws-ec2-metadata-token-ttl-seconds: 60" -X PUT "http://169.254.169.254/latest/api/token")
+    echo "IMDSv2 token fetched: $TOKEN"
+
+    # Use the token to make a metadata request
+  - |
+    INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s "http://169.254.169.254/latest/meta-data/instance-id")
+    echo "Instance ID: $INSTANCE_ID"
   - "`which aws` ec2 create-tags --region=${region} --resources $INSTANCE_ID --tags Key=Name,Value=${name_prefix}-`echo $INSTANCE_ID` | tr -d 'i-'`"
-  #- unset INSTANCE_ID
 output : { all : '| tee -a /var/log/cloud-init-output.log' }

--- a/group/templates/name.tpl
+++ b/group/templates/name.tpl
@@ -1,4 +1,5 @@
 #cloud-config
 runcmd:
-  - "`which aws` ec2 create-tags --region=${region} --resources `curl -s http://169.254.169.254/latest/meta-data/instance-id` --tags Key=Name,Value=${name_prefix}-`curl -s http://169.254.169.254/latest/meta-data/instance-id | tr -d 'i-'`"
+  - TOKEN=$(curl -H "X-aws-ec2-metadata-token-ttl-seconds: 300" -X PUT "http://169.254.169.254/latest/api/token")
+  - "`which aws` ec2 create-tags --region=${region} --resources `curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/instance-id` --tags Key=Name,Value=${name_prefix}-`curl -H "X-aws-ec2-metadata-token: $TOKEN" -s http://169.254.169.254/latest/meta-data/instance-id | tr -d 'i-'`"
 output : { all : '| tee -a /var/log/cloud-init-output.log' }

--- a/group/templates/name.tpl
+++ b/group/templates/name.tpl
@@ -1,6 +1,8 @@
 #cloud-config
 runcmd:
-  - TOKEN=$(curl -H "X-aws-ec2-metadata-token-ttl-seconds: 300" -X PUT "http://169.254.169.254/latest/api/token")
-  - INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s "http://169.254.169.254/latest/meta-data/instance-id")
+  - export TOKEN=$(curl -H "X-aws-ec2-metadata-token-ttl-seconds: 300" -X PUT "http://169.254.169.254/latest/api/token")
+  - export INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s "http://169.254.169.254/latest/meta-data/instance-id")
   - "`which aws` ec2 create-tags --region=${region} --resources $INSTANCE_ID --tags Key=Name,Value=${name_prefix}-`echo $INSTANCE_ID` | tr -d 'i-'`"
+  - unset TOKEN
+  - unset INSTANCE_ID
 output : { all : '| tee -a /var/log/cloud-init-output.log' }

--- a/group/templates/name.tpl
+++ b/group/templates/name.tpl
@@ -5,9 +5,9 @@ runcmd:
     TOKEN=$(curl -H "X-aws-ec2-metadata-token-ttl-seconds: 60" -X PUT "http://169.254.169.254/latest/api/token")
     echo "IMDSv2 token fetched: $TOKEN"
 
-    # Use the token to make a metadata request
+  # Use the token to make a metadata request
   - |
     INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s "http://169.254.169.254/latest/meta-data/instance-id")
     echo "Instance ID: $INSTANCE_ID"
-  - "`which aws` ec2 create-tags --region=${region} --resources $INSTANCE_ID --tags Key=Name,Value=${name_prefix}-`echo $INSTANCE_ID` | tr -d 'i-'`"
+    `which aws` ec2 create-tags --region=${region} --resources $INSTANCE_ID --tags Key=Name,Value=${name_prefix}-`echo $INSTANCE_ID` | tr -d 'i-'`
 output : { all : '| tee -a /var/log/cloud-init-output.log' }

--- a/group/templates/name.tpl
+++ b/group/templates/name.tpl
@@ -1,8 +1,8 @@
 #cloud-config
 runcmd:
-  - export TOKEN=$(curl -H "X-aws-ec2-metadata-token-ttl-seconds: 60" -X PUT "http://169.254.169.254/latest/api/token")
+  - export TOKEN=$(curl -H "X-aws-ec2-metadata-token-ttl-seconds: 1800" -X PUT "http://169.254.169.254/latest/api/token")
   - export INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s "http://169.254.169.254/latest/meta-data/instance-id")
+  #- unset TOKEN
   - "`which aws` ec2 create-tags --region=${region} --resources $INSTANCE_ID --tags Key=Name,Value=${name_prefix}-`echo $INSTANCE_ID` | tr -d 'i-'`"
-  - unset TOKEN
-  - unset INSTANCE_ID
+  #- unset INSTANCE_ID
 output : { all : '| tee -a /var/log/cloud-init-output.log' }

--- a/group/templates/name.tpl
+++ b/group/templates/name.tpl
@@ -9,5 +9,5 @@ runcmd:
   - |
     INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s "http://169.254.169.254/latest/meta-data/instance-id")
     echo "Instance ID: $INSTANCE_ID"
-    `which aws` ec2 create-tags --region=${region} --resources $INSTANCE_ID --tags Key=Name,Value=${name_prefix}-`echo $INSTANCE_ID` | tr -d 'i-'`
+    `which aws` ec2 create-tags --region=${region} --resources $INSTANCE_ID --tags Key=Name,Value=${name_prefix}-`echo $INSTANCE_ID | tr -d 'i-'`
 output : { all : '| tee -a /var/log/cloud-init-output.log' }

--- a/group/templates/tag.tpl
+++ b/group/templates/tag.tpl
@@ -1,1 +1,15 @@
   - "`which aws` ec2 create-tags --region ${region} --resources `curl -s http://169.254.169.254/latest/meta-data/instance-id` --tags Key=${key},Value=${value}"
+
+#cloud-config
+runcmd:
+  # Fetch IMDSv2 token
+  - |
+    TOKEN=$(curl -H "X-aws-ec2-metadata-token-ttl-seconds: 60" -X PUT "http://169.254.169.254/latest/api/token")
+    echo "IMDSv2 token fetched: $TOKEN"
+
+  # Use the token to make a metadata request
+  - |
+    INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" -s "http://169.254.169.254/latest/meta-data/instance-id")
+    echo "Instance ID: $INSTANCE_ID"
+    `which aws` ec2 create-tags --region ${region} --resources $INSTANCE_ID --tags Key=${key},Value=${value}
+output : { all : '| tee -a /var/log/cloud-init-output.log' }


### PR DESCRIPTION
**Description**
Update runcmd for IMDSv2 compatibility. With IMDSv2, we are required to pass a token with metadata requests.

**Proof**
```
> ubuntu@ip-172-31-39-138:~$ cat /var/log/cloud-init-output.log

IMDSv2 token fetched: AQAEAB8jvvQjaxEccPggu4jxre-sOkMkT0RiTLyKV1Q-uzc6KrQo8Q==
Instance ID: i-0a7e4f879034edbdd
```

**Ticket**
[DEVOPS-4320]

**Status**
No changes to apply. Downstream stacks will publish new ASG launch templates.

[DEVOPS-4320]: https://taskrabbit.atlassian.net/browse/DEVOPS-4320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ