### PR TITLE
DEVOPS-5728 | Increase metadata hop limit from 1 to 2

### DIFF
--- a/group/lt/main.tf
+++ b/group/lt/main.tf
@@ -67,7 +67,7 @@ resource "aws_launch_template" "lt" {
   metadata_options {
     http_endpoint               = "enabled"
     http_tokens                 = "required"
-    http_put_response_hop_limit = 1
+    http_put_response_hop_limit = 2
   }
 
   instance_type = var.instance_type


### PR DESCRIPTION
**Description**
Increase metadata hop limit from 1 to 2. The primary impetus here is the fact that Jenkins executes Terraform from a container so hop limit 2 is required to retain job function.

**Ticket**
[DEVOPS-5728]

[DEVOPS-5728]: https://taskrabbit.atlassian.net/browse/DEVOPS-5728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ