### PR TITLE
Set Tag Variable to Type Map to Accept Map

### DIFF
--- a/group/variables.tf
+++ b/group/variables.tf
@@ -208,7 +208,7 @@ variable "user_data" {
 
 ## ASG parameters
 variable "additional_asg_tags" {
-  type        = list(string)
+  type        = list(map)
   description = "Additional tags to apply at the ASG level, if any"
   default     = []
 }


### PR DESCRIPTION
Adds type `list(map)` for `additional_asg_tags` as it expects a map to be passed.